### PR TITLE
I added a single plus sign.

### DIFF
--- a/commands/afkCheck.js
+++ b/commands/afkCheck.js
@@ -1067,7 +1067,7 @@ class afkCheck {
             .addField('Points Log MID', 'None!');
         this.keys.forEach(m => {
             if (historyEmbed.fields[2].value == 'None!') historyEmbed.fields[2].value = `<@!${m}>`;
-            else historyEmbed.fields[2].value = `, <@!${m}>`;
+            else historyEmbed.fields[2].value += `, <@!${m}>`;
         })
         this.earlyLocation.forEach(m => {
             if (historyEmbed.fields[3].value == `None!`) historyEmbed.fields[3].value = `<@!${m.id}>`


### PR DESCRIPTION
It fixes the raid-info message so if multiple keys are popped they are all logged. Right now just the last key is logged.