### PR TITLE
Made it so the buttons show in order: Open Channel -> Start Run.

### DIFF
--- a/commands/afkCheck.js
+++ b/commands/afkCheck.js
@@ -333,6 +333,12 @@ class afkCheck {
             style: 'SUCCESS',
             customId: 'openvc'
         })
+        else lar.addComponents({
+            type: 'BUTTON',
+            label: '✅ Start Run',
+            style: 'SUCCESS',
+            customId: 'start'
+        })
         this.leaderEmbedMessage = await this.commandChannel.send({ embeds: [this.leaderEmbed], components: [lar] })
         this.runInfoMessage = await this.runInfoChannel.send({ embeds: [this.leaderEmbed] })
 
@@ -353,7 +359,10 @@ class afkCheck {
         else if (this.afkInfo.isAdvanced && !this.afkInfo.isExalt && this.settings.strings.hallsAdvancedReqsImage) this.mainEmbed.setImage(this.settings.strings.hallsAdvancedReqsImage);
         else if (this.afkInfo.isAdvanced && this.afkInfo.isExalt && this.settings.strings.exaltsAdvancedReqsImage) this.mainEmbed.setImage(this.settings.strings.exaltsAdvancedReqsImage);
         if (this.afkInfo.embed.thumbnail && !this.afkInfo.embed.removeThumbnail) this.mainEmbed.setThumbnail(this.afkInfo.embed.thumbnail)
-        this.mainEmbed.description = this.mainEmbed.description.replace("To join, **click here** {voicechannel}\n", "");
+        if (this.afkInfo.twoPhase)
+            this.mainEmbed.description = this.mainEmbed.description.replace("To join, **click here** {voicechannel}\n", "");
+        else
+            this.mainEmbed.description = this.mainEmbed.description.replace('{voicechannel}', `${this.channel}`);
         const rules = `<#${this.settings.channels.raidingrules}>` || '#raiding-rules';
 
         if (this.afkInfo.isAdvanced)


### PR DESCRIPTION
Consolidated the leaderEmbed interactions into the RSA interaction 
handler. The leaderEmbed (shown in the channel where ;afk is used) also 
displays the buttons in the Open Channel -> Start Run order.

The afks display "To join, click here" but it's a well known issue that 
you can't actually join by clicking here. This happens when a raider 
clicks the channel link in a message while it's locked. It binds for 
some reason and the raider has to join ANY other channel on the sidebar 
before they can join through the message link. Therefore, I just removed 
any mentions of the channel in the messages until the raider perms have 
been added to it.