### PR TITLE
Fixed the part where Vibot dm's about refunds for people who used poi…

### DIFF
--- a/commands/afkCheck.js
+++ b/commands/afkCheck.js
@@ -771,7 +771,7 @@ class afkCheck {
                         emitter.on('Ended', (channelID, aborted) => {
                             if (channelID == this.channel.id) {
                                 if (!aborted) this.db.query(`UPDATE users SET lastnitrouse = '${Date.now()}' WHERE id = ${interaction.user.id}`);
-                                else interaction.user.id.send(`The afk check was aborted, you have been refunded your nitro perk use.`);
+                                else interaction.user.send(`The afk check was aborted, you have been refunded your nitro perk use.`);
                             }
                         })
                     } else {
@@ -846,7 +846,7 @@ class afkCheck {
                         emitter.on('Ended', (channelID, aborted) => {
                             if (aborted && channelID == this.channel.id) {
                                 this.db.query(`UPDATE users SET points = points + ${earlyLocationCost} WHERE id = ${interaction.user.id}`);
-                                interaction.user.id.send(`The afk check was aborted, you have been refunded ${earlyLocationCost} points.`);
+                                interaction.user.send(`The afk check was aborted, you have been refunded ${earlyLocationCost} points.`);
                             }
                         })
                     }


### PR DESCRIPTION
…nts/nitro when a run gets aborted. When people would use active-channel to delete a channel with a currently active afk the code would run abortAFK but stall here. This meant the channel doesnt get deleted. This commit makes it so that won't happen anymore.