### PR TITLE
comparePositionTo returns (-inf, inf) so if the role being compared i…

### DIFF
--- a/commands/warn.js
+++ b/commands/warn.js
@@ -23,11 +23,11 @@ module.exports = {
         if (bot.settings[message.guild.id].backend.onlyUpperStaffWarnStaff) {
             let lowest_staff_role = bot.settings[message.guild.id].roles["lol"];
             if (lowest_staff_role) {
-                if (member.roles.highest.comparePositionTo(lowest_staff_role)) {
+                if (member.roles.highest.comparePositionTo(lowest_staff_role) >= 0) {
                     //the warn should only happen if message.member is like an admin or something
                     let warningRoles = settings.lists.warningRoles.length ? settings.lists.warningRoles : ['moderator', 'headrl', 'headeventrl', 'officer', 'developer']
                     let warningIds = warningRoles.map(m => settings.roles[m])
-                    if (message.member.roles.cache.filter(role => warningIds.includes(role.id)).size) return message.channel.send("Could not warn that user as they are staff and your highest role isn't high enough. Ask for a promotion and then try again.");
+                    if (!message.member.roles.cache.filter(role => warningIds.includes(role.id)).size) return message.channel.send("Could not warn that user as they are staff and your highest role isn't high enough. Ask for a promotion and then try again.");
                 }
             }
         }


### PR DESCRIPTION
…s lower its a negative number, if its the same its 0, if its higher then its positive. Right now the if statement for comparePositionTo checks if the return is 0 or not. Therefore, LOL is considered to be the only non-staff member. Anything less than or greater than LOL is considered to be staff. I added a check for comparePositionTo >= 0 to fix that.

As well, the warn would only proc if the person warning has NO upper 
staff roles. If the warner has any upper staff roles then .size on the 
filter returns a non-zero number and triggers the if. Added a ! in front 
of the upper staff role count check to fix this.