### PR TITLE
Improved the headcount command

### DIFF
--- a/commands/headcount.js
+++ b/commands/headcount.js
@@ -1,9 +1,10 @@
 const Discord = require('discord.js');
 const botSettings = require('../settings.json');
-const ErrorLogger = require('../lib/logError')
-const afkCheck = require('./afkCheck')
-const eventAfk = require('./eventAfk')
-const eventFile = require('../data/events.json')
+const emojis = require('../data/emojis.json');
+const ErrorLogger = require('../lib/logError');
+const afkCheck = require('./afkCheck');
+const eventAfk = require('./eventAfk');
+const eventFile = require('../data/events.json');
 
 var bot
 module.exports = {
@@ -69,7 +70,7 @@ module.exports = {
             if (channel) {
                 let embed = new Discord.MessageEmbed()
                     .setAuthor(`Headcount for ${run.runName} by ${message.member.nickname}`)
-                    .setDescription(`${run.headcountEmote ? `React with ${bot.emojis.cache.get(run.headcountEmote)} if you are coming\n` : ''}React with ${bot.emojis.cache.get(run.keyEmoteID)} if you have a key\nOtherwise react with your gear/class choices below`)
+                    .setDescription(run.embed.description ? run.embed.description : `${run.headcountEmote ? `React with ${bot.emojis.cache.get(run.headcountEmote)} if you are coming\n` : ''}React with ${bot.emojis.cache.get(run.keyEmoteID)} if you have a key\nOtherwise react with your gear/class choices below`)
                     .setColor(run.embed ? run.embed.color : run.color)
                     .setTimestamp()
 
@@ -81,12 +82,12 @@ module.exports = {
                 const pings = pingRole ? (typeof pingRole != "string" ? pingRole.map(r => `<@&${settings.roles[r]}>`).join(' ') : `<@&${settings.roles[pingRole]}>`) + ' @here' : '@here';
 
                 let m = await channel.send({ content: `${pings}`, embeds: [embed], components: [] })
-                if (run.headcountEmote) m.react(run.headcountEmote)
-                await m.react(run.keyEmoteID)
+                if (run.headcountEmote) await m.react(run.headcountEmote)
+                if (run.keyEmoteID) await m.react(run.keyEmoteID)
                 if (run.vialReact) await m.react(botSettings.emoteIDs.Vial)
                 for (let i of run.earlyLocationReacts) await m.react(i.emoteID)
                 for (let i of run.reacts) {
-                    if (isNaN(+i)) await m.react(botSettings.emoteIDs[i])
+                    if (isNaN(+i)) await m.react(emojis[i]["id"])
                     else await m.react(i)
                 }
             }

--- a/data/emojis.json
+++ b/data/emojis.json
@@ -29,5 +29,13 @@
     "trickster": { "tag": ":trickster:723018431275728918", "id": "723018431275728918" },
     "hallsPortal": { "tag": ":hallsPortal:716763303480786968", "id": "716763303480786968" },
     "o3": { "tag": ":oryxThree:708043327706103858", "id": "708043327706103858" },
-    "aether": { "tag": ":UTOrbofAether:720265038664826959", "id": "720265038664826959" }
+    "aether": { "tag": ":UTOrbofAether:720265038664826959", "id": "720265038664826959" },
+    "epicMysteryKey": { "tag": ":epicMysteryKey:831051424187940874", "id": "831051424187940874" },
+    "legendaryMysteryKey": { "tag": ":legendaryMysteryKey:831052176507535360", "id": "831052176507535360" },
+    "fungalKey": { "tag": ":fungalK:723001429614395402", "id": "723001429614395402" },
+    "nestKey": { "tag": ":nestK:723001429693956106", "id": "723001429693956106" },
+    "shattersKey": { "tag": ":shattersKey:1008104345197346817", "id": "1008104345197346817" },
+    "fungalPortal": { "tag": ":fungal:723001215696240660", "id": "723001215696240660" },
+    "nestPortal": { "tag": ":nest:723001215407095899", "id": "723001215407095899" },
+    "shattersPortal": { "tag": ":shatters:723001214865899532", "id": "723001214865899532" }
 }

--- a/data/events.json
+++ b/data/events.json
@@ -1783,7 +1783,7 @@
             "Plane",
             "Collo",
             "Ogmur",
-            "UTTomeoftheMushroomTriebs",
+            "UTTomeoftheMushroomTribes",
             "MarbleSeal",
             "brain",
             "mystic",
@@ -1821,7 +1821,23 @@
         "keyCount": 3,
         "color": "#fefefe",
         "isExalt": false,
-        "reacts": [],
+        "reacts": [
+            "voidd",
+            "Vial",
+            "malus",
+            "Plane",
+            "fungalPortal",
+            "nestPortal",
+            "shattersPortal",
+            "LostHallsKey",
+            "fungalKey",
+            "nestKey",
+            "shattersKey"
+        ],
+        "embed": {
+            "description": "React with any Dungeon Icon if you plan on joining\nReact with any Dungen Key if you plan on bringing any key",
+            "color": "#fefefe"
+        },
         "earlyLocationCost": 15,
         "earlyLocationReacts": []
     },


### PR DESCRIPTION
TWEAKS:
- Made ";hc exalt" better by showing each dungeon and key type. Per request of ZombleAdri
- If a event type has a parameter of "embed" with the following parameter of "description" it will now overwrite the embed description inside the headcount
- Made headcounts use "emojis.json" instead of "settings.json" for emojis. This is more fitting

BUGFIXES:
- Fixed to where if the headcount portal emoji and or key emoji were not present, it would not work.
- Fixed a typo in one of the reactions for one of the event types