### PR TITLE
;Channel Ease of Use

### DIFF
--- a/commands/createChannel.js
+++ b/commands/createChannel.js
@@ -2,6 +2,7 @@ const ChannelsCommand = require('./vibotChannels')
 const Discord = require('discord.js')
 const fs = require('fs')
 const dbInfo = require('../data/database.json')
+const logs = require('../data/logInfo.json')
 const afkCheck = require('./afkCheck')
 const ErrorLogger = require('../lib/logError')
 
@@ -13,9 +14,9 @@ module.exports = {
     alias: ['channels'],
     role: 'eventrl',
     description: 'Create a channel that stays open and is able to be edited. Useful for simply started a long lasting channel for run types where afk checks don\'t make sense. *Default cap is 50*',
-    args: '<create/open/close/rename/log/setcap> (data)',
+    args: '<create/rename/log/setcap> (data)',
     getNotes(guildid, member) {
-        return '`create <name>` creates new channel\n`open` unlocks the channel\n`close` locks the channel\n`rename <new name>` renames the channel\n`log` (c/ve) logs a dungeon complete for everyone in vc *c/v/e required for channels in vet section only*\n`setcap <#>` sets the vc cap'
+        return `\`create <name>\` creates new channel\n\`rename <new name>\` renames the channel\n\`log\` (${logs[guildid].main.map(log => log.key).join('/')}) logs a dungeon complete for everyone in vc *${logs[guildid].main.map(log => log.key).join('/')} required for channels in vet section only*\n\`setcap <#>\` sets the vc cap`
     },
     requiredArgs: 1,
     async execute(message, args, bot, db) {
@@ -35,14 +36,10 @@ module.exports = {
                 if (name == '') return message.channel.send("Please provide a name")
                 name = name.trim();
 
-                //create channel default unlocked using same code from afkcheck
-                let channel = await createChannel(name, isVet, message, bot)
-
                 //post a message in raid status
                 let embed = new Discord.EmbedBuilder()
                     .setColor('#eeeeee')
                     .setAuthor({ name: `${name}` })
-                    .setDescription(`Join \`${channel.name}\` to participate`)
                     .addFields({ name: 'Status', value: '**Closed**' })
                     .setFooter({ text: 'Started at' })
                     .setTimestamp(Date.now())
@@ -50,7 +47,27 @@ module.exports = {
                 if (isVet) raidStatus = message.guild.channels.cache.get(settings.channels.vetstatus)
                 else raidStatus = message.guild.channels.cache.get(settings.channels.eventstatus)
                 if (!raidStatus) return message.channel.send('Could not find raid-status')
-                let m = await raidStatus.send({ content: `@here`, embeds: [embed] })
+                embedComponents = new Discord.ActionRowBuilder()
+                    .addComponents([
+                        new Discord.ButtonBuilder()
+                            .setLabel('🔓 Open VC')
+                            .setStyle(2)
+                            .setCustomId('open')
+                    ])
+                let m = await raidStatus.send({ content: `@here Run will be starting very soon`, embeds: [], components: [] })
+
+                //create channel default unlocked using same code from afkcheck
+                let channel = await createChannel(name, isVet, message, bot, m)
+
+                // Modify the Raid Status Embed
+                embed.setDescription(`**Raid Leader:** ${message.member}\n**VC:** ${channel}`)
+
+                await m.edit({ content: `@here`, embeds: [embed], components: [embedComponents] })
+
+                //add interaction collectors
+                this.leaderInteractionCollector = new Discord.InteractionCollector(bot, { message: m, interactionType: Discord.InteractionType.MessageComponent, componentType: Discord.ComponentType.Button })
+                this.leaderInteractionCollector.on('collect', (interaction) => interactionHandler(interaction, m, settings, bot))
+                
 
                 //add to channels array
                 let runInfo = {
@@ -91,81 +108,6 @@ module.exports = {
                 bot.afkChecks[channel.id] = afkInfo
                 fs.writeFileSync('./afkChecks.json', JSON.stringify(bot.afkChecks, null, 4), err => { if (err) ErrorLogger.log(err, bot) })
                 return;
-            case 'open':
-                function open() {
-                    let channel = getChannel(message)
-                    if (!channel) return
-
-                    if (!channel.message) return message.channel.send(`Error finding the message in RSA, try recreating the channel`)
-                    if (!channel.channel) return message.channel.send(`Voice channel not found, try recreating it`)
-
-                    //10 second timer
-                    let iteration = 0;
-                    let timer = setInterval(unlockInterval, 5000)
-                    async function unlockInterval() {
-                        switch (iteration) {
-                            case 0:
-                                channel.message.edit(`@here Channel will open in 10 seconds...`)
-                                break;
-                            case 1:
-                                channel.message.edit(`@here Channel will open in 5 seconds...`)
-                                break;
-                            case 2:
-                                clearInterval(timer)
-                                //unlock the channel (event boi for events :^))
-                                if (channel.channel.parent.name.toLowerCase() == 'events') {
-                                    var eventBoi = message.guild.roles.cache.get(settings.roles.eventraider)
-                                    var raider = message.guild.roles.cache.get(settings.roles.raider)
-                                } else {
-                                    var raider = message.guild.roles.cache.get(settings.roles.vetraider)
-                                }
-
-                                channel.channel.permissionOverwrites.edit(raider.id, { Connect: true, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot))
-                                    .then(eventBoi && settings.backend.giveEventRoleOnDenial2 ? channel.channel.permissionOverwrites.edit(eventBoi.id, { Connect: true, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot)) : null)
-
-                                //edit message in raid status
-                                channel.embed.data.fields[0].value = '**Open**'
-                                channel.message.edit({ content: '@here', embeds: [channel.embed] })
-
-                                if (!bot.afkChecks[channel.channelId]) bot.afkChecks[channel.channelId] = {}
-                                bot.afkChecks[channel.channelId].active = true;
-                                bot.afkChecks[channel.channelId].started = Date.now();
-                                fs.writeFileSync('./afkChecks.json', JSON.stringify(bot.afkChecks, null, 4), err => { if (err) ErrorLogger.log(err, bot) })
-                                break;
-                        }
-                        iteration++;
-
-                    }
-                }
-                open()
-                break;
-            case 'close':
-                function close() {
-                    let channel = getChannel(message)
-                    if (!channel) return
-                    if (!channel.channel) return message.channel.send("Could not find your channel");
-                    //lock the channel (event boi for events :^))
-                    if (channel.channel.parent.name.toLowerCase() == 'events') {
-                        var eventBoi = message.guild.roles.cache.get(settings.roles.eventraider)
-                        var raider = message.guild.roles.cache.get(settings.roles.raider)
-                    } else {
-                        var raider = message.guild.roles.cache.get(settings.roles.vetraider)
-                    }
-
-                    channel.channel.permissionOverwrites.edit(raider.id, { Connect: false, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot))
-                        .then(eventBoi && settings.backend.giveEventRoleOnDenial2 ? channel.channel.permissionOverwrites.edit(eventBoi.id, { Connect: false, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot)) : null)
-
-                    //edit message in raid status
-                    channel.embed.data.fields[0].value = '**Closed**'
-                    channel.message.edit({ content: null, embeds: [channel.embed] })
-                    if (bot.afkChecks[channel.channelId]) {
-                        bot.afkChecks[channel.channelId].active = false;
-                        bot.afkChecks[channel.channelId].endedAt = Date.now();
-                        fs.writeFileSync('./afkChecks.json', JSON.stringify(bot.afkChecks, null, 4), err => { if (err) ErrorLogger.log(err, bot) })
-                    }
-                }
-                close()
-                break;
             case 'rename':
                 function rename() {
                     //get channel info
@@ -288,7 +230,7 @@ function getChannel(message) {
 }
 
 
-async function createChannel(name, isVet, message, bot) {
+async function createChannel(name, isVet, message, bot, rsaMessage) {
     let settings = bot.settings[message.guild.id]
     return new Promise(async (res, rej) => {
         //channel creation
@@ -320,19 +262,126 @@ async function createChannel(name, isVet, message, bot) {
         channel.permissionOverwrites.edit(raider.id, { Connect: false, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot))
         if (eventBoi && settings.backend.giveEventRoleOnDenial2) channel.permissionOverwrites.edit(eventBoi.id, { Connect: false, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot))
 
-        //Embed to remove
+        // Embed to Remove
         let embed = new Discord.EmbedBuilder()
-            .setDescription(`Whenever the run is over. React with the ❌ to delete the channel. View the timestamp for more information`)
-            .setFooter({ text: channel.id })
+            .setDescription(`**Raid Leader:** <@!${message.author.id}>\n**VC:** <#${channel.id}>\n\nWhenever the run is over. Click the button to delete the channel. View the timestamp for more information`)
+            .setFooter({ text: `${channel.id}` })
             .setTimestamp()
             .setTitle(channel.name)
-            .setColor(`#eeeeee`)
-        let m = await vibotChannels.send({ content: `${message.member}`, embeds: [embed] })
-        await m.react('❌')
-        setTimeout(() => { ChannelsCommand.watchMessage(m, bot, settings) }, 5000)
+            .setColor('#F90D4A')
+        setTimeout(async () => {
+            let m = await vibotChannels.send({ content: `${message.member}`, embeds: [embed] });
+            await ChannelsCommand.addCloseChannelButtons(bot, m, rsaMessage);
+        }, 1);
         if (!channel) rej('No channel was made')
         res(channel);
     })
+}
+
+async function interactionHandler(interaction, message, settings, bot) {
+    if (!interaction.isButton()) return;
+    if (interaction.customId == "open") {
+        veteranRL = message.guild.roles.cache.get(settings.roles.vetrl)
+        if (message.guild.members.cache.get(interaction.user.id).roles.highest.position < veteranRL.position) { return interaction.reply({ content: 'This Voice Channel is currently **CLOSED**\nYou are not a Veteran Raid Leader+ and can not open this Voice Channel', ephemeral: true}) }
+        interaction.reply({ ephemeral: true, content: "Opening channel!"})
+        function open() {
+            let channel = getChannel(interaction)
+            if (!channel) return
+
+            if (!channel.message) return message.channel.send(`Error finding the message in RSA, try recreating the channel`)
+            if (!channel.channel) return message.channel.send(`Voice channel not found, try recreating it`)
+
+            // 5 second timer
+            let iteration = 0;
+            let timer = setInterval(unlockInterval, 2500)
+            async function unlockInterval() {
+                switch (iteration) {
+                    case 0:
+                        channel.message.edit(`@here Channel will open in 5 seconds...`)
+                        break;
+                    case 1:
+                        channel.message.edit(`@here Channel will open in 2.5 seconds...`)
+                        break;
+                    case 2:
+                        clearInterval(timer)
+                        //unlock the channel (event boi for events :^))
+                        if (channel.channel.parent.name.toLowerCase() == 'events') {
+                            var eventBoi = message.guild.roles.cache.get(settings.roles.eventraider)
+                            var raider = message.guild.roles.cache.get(settings.roles.raider)
+                        } else {
+                            var raider = message.guild.roles.cache.get(settings.roles.vetraider)
+                        }
+
+                        channel.channel.permissionOverwrites.edit(raider.id, { Connect: true, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot))
+                            .then(eventBoi && settings.backend.giveEventRoleOnDenial2 ? channel.channel.permissionOverwrites.edit(eventBoi.id, { Connect: true, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot)) : null)
+
+                        //edit message in raid status
+                        channel.embed.data.fields[0].value = '**Open**'
+                        channel.message.edit({ content: '@here', embeds: [channel.embed] })
+
+                        if (!bot.afkChecks[channel.channelId]) bot.afkChecks[channel.channelId] = {}
+                        bot.afkChecks[channel.channelId].active = true;
+                        bot.afkChecks[channel.channelId].started = Date.now();
+                        fs.writeFileSync('./afkChecks.json', JSON.stringify(bot.afkChecks, null, 4), err => { if (err) ErrorLogger.log(err, bot) })
+                        break;
+                }
+                iteration++;
+
+            }
+        }
+        open()
+
+        let temp_m_components = message.components
+        for (let i = 0; i < temp_m_components.length; i++) {
+            for (let j = 0; j < temp_m_components[i].components.length; j++) {
+                if (temp_m_components[i].components[j].customId === 'open') {
+                    temp_m_components[i].components[j] = new Discord.ButtonBuilder({ label: '🔒 Close VC', customId: 'close', disabled: false, style: Discord.ButtonStyle.Primary });
+                }
+            }
+        }
+        message = await message.edit({ components: temp_m_components })
+    } else if (interaction.customId == "close") {
+        veteranRL = message.guild.roles.cache.get(settings.roles.vetrl)
+        if (message.guild.members.cache.get(interaction.user.id).roles.highest.position < veteranRL.position) { return interaction.reply({ content: 'This Voice Channel is currently **OPEN**\nYou are not a Veteran Raid Leader+ and can not close this Voice Channel', ephemeral: true}) }
+        interaction.reply({ ephemeral: true, content: "Closing channel!"})
+        function close() {
+            let channel = getChannel(interaction)
+            if (!channel) return
+            if (!channel.channel) return message.channel.send("Could not find your channel");
+            //lock the channel (event boi for events :^))
+            if (channel.channel.parent.name.toLowerCase() == 'events') {
+                var eventBoi = message.guild.roles.cache.get(settings.roles.eventraider)
+                var raider = message.guild.roles.cache.get(settings.roles.raider)
+            } else {
+                var raider = message.guild.roles.cache.get(settings.roles.vetraider)
+            }
+
+            channel.channel.permissionOverwrites.edit(raider.id, { Connect: false, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot))
+                .then(eventBoi && settings.backend.giveEventRoleOnDenial2 ? channel.channel.permissionOverwrites.edit(eventBoi.id, { Connect: false, ViewChannel: true }).catch(er => ErrorLogger.log(er, bot)) : null)
+
+            //edit message in raid status
+            channel.embed.data.fields[0].value = '**Closed**'
+            channel.message.edit({ content: null, embeds: [channel.embed] })
+            if (bot.afkChecks[channel.channelId]) {
+                bot.afkChecks[channel.channelId].active = false;
+                bot.afkChecks[channel.channelId].endedAt = Date.now();
+                fs.writeFileSync('./afkChecks.json', JSON.stringify(bot.afkChecks, null, 4), err => { if (err) ErrorLogger.log(err, bot) })
+            }
+        }
+        close()
+
+        let temp_m_components = message.components
+        for (let i = 0; i < temp_m_components.length; i++) {
+            for (let j = 0; j < temp_m_components[i].components.length; j++) {
+                if (temp_m_components[i].components[j].customId === 'close') {
+                    temp_m_components[i].components[j] = new Discord.ButtonBuilder({ label: '🔓 Open VC', customId: 'open', disabled: false, style: Discord.ButtonStyle.Secondary });
+                }
+            }
+        }
+        message = await message.edit({ components: temp_m_components })
+    } else {
+        interaction.reply({ content: "Something went wrong, please try again!", ephemeral: true })
+    }
 }
 
 function moduleIsAvailable(path) {

--- a/commands/log.js
+++ b/commands/log.js
@@ -111,16 +111,11 @@ function confirm(runInfo, message, count) {
             .setDescription(`Are you sure you want to log ${parseInt(count) * multiplier} ${runInfo.confirmSuffix}?`)
             .setFooter({ text: message.member.displayName })
             .setTimestamp()
-        let confirmMessage = await message.channel.send({ embeds: [confirmEmbed] })
-        let confirmCollector = new Discord.ReactionCollector(confirmMessage, { filter: (r, u) => !u.bot && u.id == message.author.id && (r.emoji.name === '✅' || r.emoji.name === '❌') })
-        confirmMessage.react('✅')
-        confirmMessage.react('❌')
-        confirmCollector.on('collect', async function (r, u) {
-            confirmMessage.delete()
-            if (r.emoji.name === '✅') return res(true)
-            else return res(false)
+        await message.channel.send({ embeds: [confirmEmbed] }).then(async confirmMessage => {
+            if (await confirmMessage.confirmButton(message.author.id)) {
+                return res(true)
+            } else return res(false)
         })
-        confirmCollector.on('end', async (r, u) => { confirmMessage.delete(); res(false); })
     })
 }
 

--- a/commands/verification.js
+++ b/commands/verification.js
@@ -80,7 +80,7 @@ module.exports = {
 
             const staff = blGuild.members.cache.get(blInfo.modid);
             if (!staff || staff.id == bot.user.id || staff.roles.highest.comparePositionTo(bot.settings[blGuild.id].roles.security) < 0) {
-                 if (guild.id == botSettings.hallsId) return u.send(`You are currently blacklisted from the __${blGuild.name}__ server and cannot verify. The person who blacklisted you is no longer staff. Please DM any online officer to appeal.`);
+                 if (guild.id == botSettings.hallsId) return u.send(`You are currently blacklisted from the __${blGuild.name}__ server and cannot verify. The person who blacklisted you is no longer staff. Please DM any online security to appeal.`);
                  return u.send(`You are currently blacklisted from the __${blGuild.name}__ server and cannot verify. The person who blacklisted you is no longer staff. Please DM me and send mod-mail to that server to appeal.`);
             }
 


### PR DESCRIPTION
When doing ;channel, you have to use 2 additional commands ;channel open and ;channel close to open and close respectively, this essentially moves that to Buttons, where you can open and close the channel very easily.
- Also made ;log's confirmation message to buttons
- Fixed typo in the verification.js file, the "officer" was meant to be changed to "security sooner, but nobody caught it