### PR TITLE
Bot Ready Refactor Hotfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ require('./lib/extensions.js')
 // Import Internal Libraries
 const ErrorLogger = require(`./lib/logError`)
 const CommandLogger = require('./lib/logCommand')
-const botSetup = require('./botSetup.js')
 
 // Specific Commands
 const verification = require('./commands/verification')
@@ -26,6 +25,7 @@ const rootCas = require('ssl-root-cas').create();
 require('https').globalAgent.options.ca = rootCas;
 
 const bot = require('./botMeta.js').bot
+const botSetup = require('./botSetup.js')
 
 
 // Bot Event Handlers


### PR DESCRIPTION
Theory is that something in `commands/*.js` populates the guild cache -- this PR inadvertently ran DB setup before `command/*.js which meant that we connected to DBs before the cache is populated