### PR TITLE
Refactor out member management

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ bot.on("ready", async () => {
     await botSetup.setup(bot)
 });
 
-bot.on('guildMemberAdd', member => {
+bot.on('guildMemberAdd', async (member) => {
     if (!bot.dbs[member.guild.id]) return
 
     await memberHandler.checkWasSuspended(bot, member)
@@ -180,17 +180,17 @@ bot.on('guildMemberUpdate', async (oldMember, newMember) => {
 
     if (!oldMember.roles.cache.equals(newMember.roles.cache)) return
 
-    if (settings.commands.prunerushers) memberHandler.pruneRushers(bot.dbs[newMember.guild.id], settings.roles.rusher, oldMember, newMember)
+    if (settings.commands.prunerushers) await memberHandler.pruneRushers(bot.dbs[newMember.guild.id], settings.roles.rusher, oldMember, newMember)
 
     if (newMember.roles.cache.has(settings.roles.lol)) return
 
     await memberHandler.updateAffiliateRoles(bot, newMember)
 })
 
-bot.on('guildMemberRemove', member => {
+bot.on('guildMemberRemove', async (member) => {
     if (!bot.dbs[member.guild.id]) return
 
-    memberHandler.checkSuspensionEvasion(bot, member)
+    await memberHandler.detectSuspensionEvasion(bot, member)
 })
 
 bot.on('messageReactionAdd', async (r, u) => {


### PR DESCRIPTION
What it says on the tin. A few small behavior changes:

- When a member tries to leave, we will still veriblacklist them and update their row in the suspension table even if we cannot find a mod log channel.
- Add support for managing affiliate staff / vet affiliate staff roles with more than one partner server

Questions:
- [x] How do I log errors please send help I want to log them somewhere but where
- [x] Is this too fancy to be readable? I'm sorry I'm a functional programmer at heart
https://github.com/Thomasc33/ViBot/blob/3cf92b4e9e5be64020c66c38a1eec463dafd96a2/memberHandler.js#L100-L102

> **Note:** Untested, DB was down and also idk how to test join/leave stuff, maybe we just merge it and see if anything explodes?