### PR TITLE
Fix permasuspend & unverify removing managed roles

### DIFF
--- a/commands/permaSuspend.js
+++ b/commands/permaSuspend.js
@@ -62,7 +62,7 @@ module.exports = {
             let userRolesString = '',
                 userRoles = []
             member.roles.cache.each(r => {
-                if (!r.managed) {
+                if (!(r.managed || settings.lists.discordRoles.map(role => settings.roles[role]).includes(r.id))) {
                     userRoles.push(r.id)
                     userRolesString = userRolesString.concat(`${r.id} `)
                 }
@@ -72,7 +72,8 @@ module.exports = {
                     embed.data.fields[3].value += `, <@&${r.id}>`
                 }
             })
-            await member.edit({ roles: [pSuspendRole] })
+            await member.roles.remove(userRoles)
+            setTimeout(() => { member.roles.add(pSuspendRole.id); }, 1000)
             if (overwrite) db.query(`UPDATE suspensions SET perma = true, uTime = '0', modid = '${message.member.id}' WHERE id = '${member.id}' AND suspended = true`)
             else db.query(`INSERT INTO suspensions (id, guildid, suspended, uTime, reason, modid, roles, logmessage, perma) VALUES ('${member.id}', '${message.guild.id}', true, '0', ${db.escape(reason)}, '${message.author.id}', '${userRolesString}', 'n/a', true);`)
             message.channel.send(`${member} has been permanently suspended`)

--- a/commands/unverify.js
+++ b/commands/unverify.js
@@ -19,6 +19,14 @@ module.exports = {
         if (member.roles.highest.position >= message.guild.roles.cache.get(bot.settings[message.guild.id].roles.eventrl).position)
             return message.channel.send('You can not unverify EO+');
 
+        //get role list, ignoring Discord managed roles
+        let userRoles = []
+        member.roles.cache.each(r => {
+            if (r.managed) return
+            if (settings.lists.discordRoles.map(role => settings.roles[role]).includes(r.id)) return
+            userRoles.push(r.id)
+        })
+
         const reason = args.join(' ');
         //unverify
         let embed = new Discord.EmbedBuilder()
@@ -28,7 +36,7 @@ module.exports = {
             .addFields([{name: 'Unverified By', value: `<@!${message.author.id}>`, inline: true}])
             .addFields([{name: 'Reason', value: reason || 'None!'}])
             .setTimestamp(Date.now());
-        member.roles.set([])
+        member.roles.remove(userRoles)
             .then(() => member.setNickname(''))
             .then(async() => { member.send(`You have been unverified${reason ? ': ' + reason : ''}. Please contact ${message.author} \`${message.author.tag}\` to appeal.`); })
             .then(() =>     message.guild.channels.cache.get(settings.channels.modlogs).send({ embeds: [embed] }))


### PR DESCRIPTION
Both the `permasuspend` and `unverify` commands attempt to remove all roles from the user, this change makes sure it doesn't include Discord managed roles such as Nitro or Subscriber.