### PR TITLE
Fix modlog message not sending after unmute -> rejoin

### DIFF
--- a/memberHandler.js
+++ b/memberHandler.js
@@ -53,9 +53,9 @@ module.exports = {
 
         const [[{ mute_count }], ] = await db.promise().query(`SELECT COUNT(*) as mute_count FROM mutes WHERE id = ? AND muted = true`, [member.id])
         if (mute_count !== 0) {
-            member.roles.add(bot.settings[member.guild.id].roles.muted)
-            const modlogChannel = modlogChannel(bot, member.guild)
-            if (modlogChannel) await modlogChannel.send(`${member} rejoined server after leaving while muted. Giving muted role back.`)
+            await member.roles.add(bot.settings[member.guild.id].roles.muted)
+            const logChannel = modlogChannel(bot, member.guild)
+            if (logChannel) await logChannel.send(`${member} rejoined server after leaving while muted. Giving muted role back.`)
         }
     },
     async pruneRushers(db, rusherRoleId, oldMember, newMember) {


### PR DESCRIPTION
For some reason this bug is only in my dev env not prod but whatever

```
ReferenceError: Cannot access 'modlogChannel' before initialization
    at Object.checkWasMuted (/home/Huntifer/Projects/ViBot/memberHandler.js:58:35)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Client.<anonymous> (/home/Huntifer/Projects/ViBot/index.js:108:5)
```