### PR TITLE
Fix prefix change logging bug; Swap osanc and halls VAS prefixes

### DIFF
--- a/data/partneredServers.json
+++ b/data/partneredServers.json
@@ -5,7 +5,7 @@
         "name": "Oryx Sanctuary",
         "affiliatelist": ["admin", "moderator", "officer", "headrl", "headdev", "developer", "assistantdev", "security", "vetrl", "rl", "almostrl", "eventrl"],
         "vaslist": ["vetrl", "headdev", "headrl", "officer", "moderator", "admin"],
-        "prefix": "'"
+        "prefix": ">"
     },
     {
         "guildId": 708026927721480254,
@@ -13,7 +13,7 @@
         "name": "Lost Halls",
         "affiliatelist": ["admin", "moderator", "officer", "headrl", "headeventrl", "headdev", "security", "developer", "assistantdev", "vetrl", "rl", "warden", "almostrl", "eventrl"],
         "vaslist": ["vetrl", "headdev", "headeventrl", "headrl", "officer", "moderator"],
-        "prefix": ">"
+        "prefix": "'"
     },
     {
         "guildId": 934611202787643412,
@@ -21,7 +21,7 @@
         "name": "Dev Halls",
         "affiliatelist": ["admin", "moderator", "officer", "headrl", "headeventrl", "headdev", "security", "developer", "assdev", "vetrl", "rl", "warden", "almostrl", "eventrl"],
         "vaslist": ["vetrl", "headdev", "headeventrl", "headrl", "officer", "moderator"],
-        "prefix": ">"
+        "prefix": "'"
     },
     {
         "guildId": 701483950559985705,
@@ -29,6 +29,6 @@
         "name": "osanc test",
         "affiliatelist": ["admin", "moderator", "officer", "headrl", "headdev", "dev", "assdev", "security", "vetrl", "rl", "almostrl", "el"],
         "vaslist": ["vetrl", "headdev", "headrl", "officer", "moderator", "admin"],
-        "prefix": "'"
+        "prefix": ">"
     }
 ]

--- a/memberHandler.js
+++ b/memberHandler.js
@@ -93,8 +93,9 @@ module.exports = {
 
             if (partneredMember.roles.highest.position == partneredRoles.vetaffiliate.position && !partneredMember.displayName.startsWith(partneredServer.prefix)) {
                 const baseName = partneredMember.displayName.replace(/^(\W+)/, '')
+                const oldName = partneredMember.displayName
                 await partneredMember.setNickname(`${partneredServer.prefix}${baseName}`, 'Automatic Nickname Change: User just got Veteran Affiliate Staff as their highest role')
-                await modLog(partneredMember, partneredModLogs, partneredMember.roles.highest.hexColor, `Automatic Prefix Change for ${partneredMember}\nOld Nickname: \`${partneredMember.displayName}\`\nNew Nickname: \`${partneredMember.displayName}\`\nPrefix: \`${partneredServer.prefix}\``)
+                await modLog(partneredMember, partneredModLogs, partneredMember.roles.highest.hexColor, `Automatic Prefix Change for ${partneredMember}\nOld Nickname: \`${oldName}\`\nNew Nickname: \`${partneredMember.displayName}\`\nPrefix: \`${partneredServer.prefix}\``)
             }
         }))
     },


### PR DESCRIPTION
Prefix backwards explained by Bark: https://canary.discord.com/channels/343704644712923138/420322594604974080/1095062695306330225

My understanding is that for server X, if `{'X': {'prefix': 'z'}}`, VAS in X should get the prefix 'z'

## Changelog

**Bugs:**
- Fix bot assigning the wrong prefixes for osanc vs halls
- Fix the mod log about an automatic nickname change not listing any changes (even though there were definitely changes)