### PR TITLE
Fix eafk bad emoji objects

### DIFF
--- a/commands/eventAfk.js
+++ b/commands/eventAfk.js
@@ -39,8 +39,8 @@ module.exports = {
                 color: event.color,
                 thumbnail: event.thumbnail,
                 description: `To join, **click here** {voicechannel}\n` +
-                `${event.keyEmote ? `If you have a key react with <${bot.storedEmojis[event.keyEmote].text}>\n` : ''}` + 
-                `${event.reacts.length > 0 ? `To indicate your class or gear choices, react with ${event.reacts.map(m => `${bot.storedEmojis[m]}`).join(' ')}\n` : ''}` +
+                `${event.keyEmote ? `If you have a key react with ${bot.storedEmojis[event.keyEmote].text}\n` : ''}` + 
+                `${event.reacts.length > 0 ? `To indicate your class or gear choices, react with ${event.reacts.map(m => bot.storedEmojis[m].text).join(' ')}\n` : ''}` +
                 `If you have one of the following roles ${settings.lists.perkRoles.map(role => `<@&${settings.roles[role]}>`).join(', ')} ` +
                 `react with <:nitro:701491230349066261> to get into VC`
             }


### PR DESCRIPTION
**Bugfix**:
- Fixed eafk emoji bug. Broke: `[object Object] [object Object] [object Object] [object Object]` Woke: `<actual emojis> <idk> <i cant type them on github>`