### PR TITLE
Fixed jobs/unban to match unsuspend fix

### DIFF
--- a/jobs/unban.js
+++ b/jobs/unban.js
@@ -30,9 +30,11 @@ async function tryUnsuspend(bot, g, row, isVetBan) {
             const rolesString = row.roles;
             rolesString.split(' ').forEach(r => { if (r !== '') roles.push(r) })
 
-            await member.edit({ roles }).catch(er => ErrorLogger.log(er, bot, g))
-            setTimeout(() => {
-                if (member.roles.cache.has(settings.roles.tempsuspended)) {member.edit({ roles }).catch(er => ErrorLogger.log(er, bot, g))}
+            await member.roles.add(roles).catch(er => ErrorLogger.log(er, bot, g));
+            setTimeout(async () => {
+                if (member.roles.cache.has(settings.roles.tempsuspended)) await member.roles.remove(settings.roles.tempsuspended).catch(er => ErrorLogger.log(er, bot, g));
+                if (member.roles.cache.has(settings.roles.permasuspended)) await member.roles.remove(settings.roles.permasuspended);
+                if (settings.backend.useUnverifiedRole && member.roles.cache.has(settings.roles.unverified)) await member.roles.remove(settings.roles.unverified)
             }, 5000)
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibot",
-  "version": "6.12.1",
+  "version": "6.12.2",
   "description": "ViBot",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Applied same patch to jobs/unban.js as I did to unsuspend.js

Tested and it removes unsuspension and adds correct roles back automatically upon time running out.

