### PR TITLE
Helmet rune alias

### DIFF
--- a/data/keypop.json
+++ b/data/keypop.json
@@ -218,6 +218,40 @@
             "schema": "advancedNestPops",
             "name": "Advanced Nest",
             "modded": true
+        },
+        "helmetrune": {
+            "templateID": 28,
+            "alias": [
+                "h",
+                "helm",
+                "helmet"
+            ],
+            "points": "runepop",
+            "schema": "helmetRunePops",
+            "name": "Helmet Rune",
+            "modded": false
+        },
+        "shieldrune": {
+            "templateID": 22,
+            "alias": [
+                "sh",
+                "shield"
+            ],
+            "points": "runepop",
+            "schema": "shieldRunePops",
+            "name": "Shield Rune",
+            "modded": false
+        },
+        "swordrune": {
+            "templateID": 23,
+            "alias": [
+                "sw",
+                "sword"
+            ],
+            "points": "runepop",
+            "schema": "swordRunePops",
+            "name": "Sword Rune",
+            "modded": false
         }
     },
     "451171819672698920": {
@@ -292,7 +326,8 @@
             "templateID": 24,
             "alias": [
                 "h",
-                "helm"
+                "helm",
+                "helmet"
             ],
             "points": "runepop",
             "schema": "helmetRunePops",
@@ -337,7 +372,8 @@
             "templateID": 28,
             "alias": [
                 "h",
-                "helm"
+                "helm",
+                "helmet"
             ],
             "points": "runepop",
             "schema": "helmetRunePops",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibot",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "ViBot",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
# New version 7.8.1

## keypop.json now has a new alias "helmet" added to the list

### Quality of life
- Now allows the command `;pop helmet (name)` to be used as requested
- Added the rune pops to DevHalls server for future testing