### PR TITLE
Oryx Feedback

### DIFF
--- a/commands/log.js
+++ b/commands/log.js
@@ -88,7 +88,9 @@ module.exports = {
         if (guildQuota) {
             toUpdate.forEach(update => {
                 const runQuota = guildQuota.quotas.filter(q => q.id == update)
-                if (runQuota.length) quota.update(message.guild, db, bot, settings, guildQuota, runQuota)
+                if (runQuota.length) {
+                    quota.update(message.guild, db, bot, settings, guildQuota, runQuota[0])
+                }
             })
         }
     }

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -39,12 +39,18 @@
             "runeSwordPops",
             "runeHelmetPops",
             "incantationPops",
-            "fameMinutesLead"
+            "fameMinutesLead",
+            "oryxFeedback",
+            "currentweekOryxFeedback"
         ],
         "currentweeks": [
             {
                 "case": "cultsLead",
                 "currentWeekName": "currentweekCult"
+            },
+            {
+                "case": "oryxFeedback",
+                "currentWeekName": "currentweekOryxFeedback"
             },
             {
                 "case": "voidsLead",
@@ -168,12 +174,18 @@
             "runeSwordPops",
             "runeHelmetPops",
             "incantationPops",
-            "fameMinutesLead"
+            "fameMinutesLead",
+            "oryxFeedback",
+            "currentweekOryxFeedback"
         ],
         "currentweeks": [
             {
                 "case": "cultsLead",
                 "currentWeekName": "currentweekCult"
+            },
+            {
+                "case": "oryxFeedback",
+                "currentWeekName": "currentweekOryxFeedback"
             },
             {
                 "case": "voidsLead",

--- a/data/leaderBoardInfo.json
+++ b/data/leaderBoardInfo.json
@@ -123,7 +123,8 @@
                     "embedColor": "#8c00ff",
                     "dbRows": [
                         "feedback",
-                        "shattersFeedback"
+                        "shattersFeedback",
+                        "oryxFeedback"
                     ]
                 },
                 {

--- a/data/logInfo.json
+++ b/data/logInfo.json
@@ -34,6 +34,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true,
@@ -72,6 +73,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -109,6 +111,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -147,6 +150,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -196,6 +200,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -234,6 +239,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -272,6 +278,46 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
+                    "rollingQuota"
+                ],
+                "logVet": true
+            },
+            {
+                "key": "of",
+                "name": "oryx feedback",
+                "alias": [
+                    "ofeedback",
+                    "ofb"
+                ],
+                "multiply": null,
+                "allowAssists": false,
+                "confirm": true,
+                "confirmSuffix": "oryx feedbacks",
+                "main": "oryxFeedback",
+                "currentweek": "currentweekOryxFeedback",
+                "color": "#990000",
+                "icon": "https://media.discordapp.net/attachments/1114574154021208186/1189019181421690960/information-gb78b31705_640-1920w.png?ex=659ca367&is=658a2e67&hm=a712c7be02c1638b070f19d888f60ad94cfffcb17747cd0930fa9d5ec68ffd1b&=&format=webp&quality=lossless",
+                "desc": "`Oryx Feedback`",
+                "toUpdate": "raiding",
+                "toDisplay": [
+                    "currentweekCult",
+                    "currentweekVoid",
+                    "currentweekShatters",
+                    "currentWeekHardmodeShattersLead",
+                    "currentweekFungals",
+                    "currentweekNests",
+                    "currentWeekAdvancedNestsLead",
+                    "currentweekSteamwork",
+                    "currentWeekAdvancedSteamworksLead",
+                    "currentweekMoonlight",
+                    "currentweekFullskipsLead",
+                    "currentWeekOryxLead",
+                    "currentWeekSilentOryxLead",
+                    "currentweekAssists",
+                    "currentweekFeedback",
+                    "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -309,6 +355,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -349,6 +396,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -389,6 +437,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -687,6 +736,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true,
@@ -725,6 +775,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -762,6 +813,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -800,6 +852,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -849,6 +902,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -887,6 +941,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -925,6 +980,46 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
+                    "rollingQuota"
+                ],
+                "logVet": true
+            },
+            {
+                "key": "of",
+                "name": "oryx feedback",
+                "alias": [
+                    "ofeedback",
+                    "ofb"
+                ],
+                "multiply": null,
+                "allowAssists": false,
+                "confirm": true,
+                "confirmSuffix": "oryx feedbacks",
+                "main": "oryxFeedback",
+                "currentweek": "currentweekOryxFeedback",
+                "color": "#990000",
+                "icon": "https://media.discordapp.net/attachments/1114574154021208186/1189019181421690960/information-gb78b31705_640-1920w.png?ex=659ca367&is=658a2e67&hm=a712c7be02c1638b070f19d888f60ad94cfffcb17747cd0930fa9d5ec68ffd1b&=&format=webp&quality=lossless",
+                "desc": "`Oryx Feedback`",
+                "toUpdate": "raiding",
+                "toDisplay": [
+                    "currentweekCult",
+                    "currentweekVoid",
+                    "currentweekShatters",
+                    "currentWeekHardmodeShattersLead",
+                    "currentweekFungals",
+                    "currentweekNests",
+                    "currentWeekAdvancedNestsLead",
+                    "currentweekSteamwork",
+                    "currentWeekAdvancedSteamworksLead",
+                    "currentweekMoonlight",
+                    "currentweekFullskipsLead",
+                    "currentWeekOryxLead",
+                    "currentWeekSilentOryxLead",
+                    "currentweekAssists",
+                    "currentweekFeedback",
+                    "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -962,6 +1057,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -1002,6 +1098,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true
@@ -1042,6 +1139,7 @@
                     "currentweekAssists",
                     "currentweekFeedback",
                     "currentweekshattersFeedback",
+                    "currentweekOryxFeedback",
                     "rollingQuota"
                 ],
                 "logVet": true

--- a/data/quotas.json
+++ b/data/quotas.json
@@ -48,6 +48,7 @@
                     { "column": "currentweekAssists", "emoji": ":handshake:", "name": "Assists", "value": 0.5 },
                     { "column": "currentweekFeedback", "emoji": "<:feedback:858920770806087710>", "name": "Feedback", "value": 1 },
                     { "column": "currentweekshattersFeedback", "emoji": "<:shattersFeedback:1071433377879707728>", "name": "Shatters Feedback", "value": 2 },
+                    { "column": "currentweekOryxFeedback", "emoji": "<:oryxFeedback:1189018214949208195>", "name": "Oryx Feedback", "value": 2 },
                     { "column": "rollingQuota", "emoji": ":hourglass:", "name": "Rolled Quota", "value": 1, "rolling": true }
                 ],
                 "voteInfo": {
@@ -138,6 +139,7 @@
                     { "column": "currentweekAssists", "emoji": ":handshake:", "name": "Assists", "value": 0.5 },
                     { "column": "currentweekFeedback", "emoji": "<:feedback:858920770806087710>", "name": "Feedback", "value": 1 },
                     { "column": "currentweekshattersFeedback", "emoji": "<:shattersFeedback:1071433377879707728>", "name": "Shatters Feedback", "value": 2 },
+                    { "column": "currentweekOryxFeedback", "emoji": "<:oryxFeedback:1189018214949208195>", "name": "Oryx Feedback", "value": 2 },
                     { "column": "rollingQuota", "emoji": ":hourglass:", "name": "Rolled Quota", "value": 1, "rolling": true }
                 ],
                 "voteInfo": {

--- a/data/stats.json
+++ b/data/stats.json
@@ -224,6 +224,11 @@
                     },
                     {
                         "name": null,
+                        "emoji": "oryxFeedback",
+                        "row": "oryxFeedback"
+                    },
+                    {
+                        "name": null,
                         "emoji": "twitterHandshake",
                         "row": "assists"
                     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibot",
-  "version": "8.2.1",
+  "version": "8.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibot",
-      "version": "8.2.1",
+      "version": "8.5.0",
       "license": "ISC",
       "dependencies": {
         "@google-cloud/vision": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibot",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "ViBot",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
# ViBot [8.6.0]
## Changelog
### Features
- ;log template for oryx feedback
- ;changelog includes "oryxFeedback" and "currentweekOryxFeedback"
- ;stats includes "oryxFeedback"
- Added oryx feedbacks as a quota for 2 points for the "raiding" template
### Changes
- Added a new emoji "oryxFeedback"
- Added a new row for "users" - "oryxFeedback"
- Added a new row for "users" - "currentweekOryxFeedback"
### Bugs
- ;log won't update the display for quota, fixed by fetching the object inside of an array
## Summary
### Overview
Introduction of Oryx Feedbacks, they are now loggable by RLs via the ;log command.
It introduces new database rows, emojis, and overall added to json files like ;stats and ;lb
### Examples
![image](https://github.com/ViBotTeam/ViBot/assets/46399778/f83b6861-e39f-498c-b097-e78e3884e1fb)
![image](https://github.com/ViBotTeam/ViBot/assets/46399778/a0987c62-2446-4513-af82-c94aa9efefd9)
![information-gb78b31705_640-1920w](https://github.com/ViBotTeam/ViBot/assets/46399778/1f577eb5-ece8-422f-b8ff-c4bc22c1f74e)