### PR TITLE
Activity-log ignore head developer

### DIFF
--- a/data/quotas.json
+++ b/data/quotas.json
@@ -91,7 +91,7 @@
         "totalUnexcused": "totalUnexcused",
         "consecutiveUnexcused": "consecutiveUnexcused",
         "consecutiveLeave": "consecutiveLeave",
-        "ignoreRoles": ["officer", "moderator", "headrl", "admin"],
+        "ignoreRoles": ["officer", "moderator", "headrl", "admin", "headdev"],
         "ignoreRolesDisplay": [],
         "roleDisplay": [],
         "quotas": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibot",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "description": "ViBot",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Now head develoepr is ignored from Activity-Log

# ViBot [8.7.1]
## Changelog
### Changes
- Head Developer now gets ignored from quota