### PR TITLE
Added exaltations to ;poll

### DIFF
--- a/commands/poll.js
+++ b/commands/poll.js
@@ -31,9 +31,9 @@ module.exports = {
 
         let embedNew = new Discord.EmbedBuilder()
             .setColor('#fefefe')
-            .setTitle(poll.name)
-            .setDescription(`Please react to one of the below dungeons\nOr react to one of the below gear or items that you're bringing\n\n${poll.reacts.map(react => `${bot.storedEmojis[react.emoji].text}: ${react.name}`).join('\n')}`)
-            .setFooter({ text: `Started by ${message.guild.members.cache.get(message.author.id).nickname}` })
+            .setTitle(poll.name.charAt(0).toUpperCase() + poll.name.slice(1))
+            .setDescription(`Please react to one of the below dungeons.\nAlternatively, please react to one of the items displayed below that you are bringing.\n\n${poll.reacts.map(react => `${bot.storedEmojis[react.emoji].text}: ${react.name}`).join('\n')}`)
+            .setFooter({ text: `Started by ${message.member.displayName}` })
         let newMessage = await message.channel.send({ embeds: [embedNew] })
         poll.reacts.map(async react => {
             await newMessage.react(bot.storedEmojis[react.emoji].id)

--- a/data/poll.json
+++ b/data/poll.json
@@ -62,7 +62,7 @@
         {
             "name": "exaltations",
             "aliases": [
-                "exalts"
+                "exalts", "ex", "exalt"
             ],
             "reacts": [
                 {
@@ -74,8 +74,12 @@
                     "emoji": "cultist"
                 },
                 {
+                    "name": "Oryx Sanctuary",
+                    "emoji": "oryxThree"
+                },
+                {
                     "name": "The Shatters",
-                    "emoji": "forgottenKing"
+                    "emoji": "forgottenking"
                 },
                 {
                     "name": "Fungal Cavern",
@@ -84,6 +88,18 @@
                 {
                     "name": "The Nest",
                     "emoji": "killerBeeQueen"
+                },
+                {
+                    "name": "Advanced Nest",
+                    "emoji": "advancedNestBee"
+                },
+                {
+                    "name": "Kogbold Steamworks",
+                    "emoji": "SteamworksBoss"
+                },
+                {
+                    "name": "Advanced Kogbold Steamworks",
+                    "emoji": "exaltedAdvancedSteamworks"
                 }
             ]
         },
@@ -167,7 +183,7 @@
         {
             "name": "exaltations",
             "aliases": [
-                "exalts"
+                "exalts", "ex", "exalt"
             ],
             "reacts": [
                 {
@@ -179,8 +195,12 @@
                     "emoji": "cultist"
                 },
                 {
+                    "name": "Oryx Sanctuary",
+                    "emoji": "oryxThree"
+                },
+                {
                     "name": "The Shatters",
-                    "emoji": "forgottenKing"
+                    "emoji": "forgottenking"
                 },
                 {
                     "name": "Fungal Cavern",
@@ -189,6 +209,18 @@
                 {
                     "name": "The Nest",
                     "emoji": "killerBeeQueen"
+                },
+                {
+                    "name": "Advanced Nest",
+                    "emoji": "advancedNestBee"
+                },
+                {
+                    "name": "Kogbold Steamworks",
+                    "emoji": "SteamworksBoss"
+                },
+                {
+                    "name": "Advanced Kogbold Steamworks",
+                    "emoji": "exaltedAdvancedSteamworks"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibot",
-  "version": "8.7.1",
+  "version": "8.7.2",
   "description": "ViBot",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
8.7.1 -> 8.7.2

- Small grammar adjustments to ;poll text.

- ;poll now capitalises the first letter of the title for all poll commands.

- The footer now shows the member displayName, not nickname.

- The exalts poll has two new aliases: "ex" and "exalt".

- The shatters emoji has been updated to the new graphic.

- The exalts poll now shows all exalt dungeons.

# ViBot [8.7.2]
## Changelog

- Small grammar adjustments to ;poll text.
- ;poll now capitalises the first letter of the title for all poll commands.
- The footer now shows the member displayName, not nickname.
- The exalts poll has two new aliases: "ex" and "exalt".
- The shatters emoji has been updated to the new graphic.
- The exalts poll now shows all exalt dungeons.