### PR TITLE
Typo in embed when closing modmail

### DIFF
--- a/eslint-plugin-vibot-rules/package.json
+++ b/eslint-plugin-vibot-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vibot-rules",
-  "version": "8.8.2",
+  "version": "0.0.0",
   "description": "Custom ESLint rules for ViBot",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibot",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "description": "ViBot",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
# ViBot [8.8.2]
## Changelog 
### Changes
- Changed spelling `permenantly` to `permanently`.