### PR TITLE
Add advanced run completes to DB

### DIFF
--- a/data/leaderBoardInfo.json
+++ b/data/leaderBoardInfo.json
@@ -310,11 +310,27 @@
                     ]
                 },
                 {
-                    "prettyName": "Steamwork Completes",
+                    "prettyName": "Advanced Nest Completes",
+                    "emoji": "advancedNestBee",
+                    "embedColor": "#469628",
+                    "dbRows": [
+                        "advancedNestRuns"
+                    ]
+                },
+                {
+                    "prettyName": "Steamworks Completes",
                     "emoji": "SteamworksBoss",
                     "embedColor": "#3b3e46",
                     "dbRows": [
                         "steamworkRuns"
+                    ]
+                },
+                {
+                    "prettyName": "Advanced Steamworks Completes",
+                    "emoji": "exaltedAdvancedSteamworks",
+                    "embedColor": "#3b3e46",
+                    "dbRows": [
+                        "advancedSteamworkRuns"
                     ]
                 },
                 {

--- a/data/stats.json
+++ b/data/stats.json
@@ -116,8 +116,18 @@
                     },
                     {
                         "name": null,
+                        "emoji": "advancedNestBee",
+                        "row": "advancedNestRuns"
+                    },
+                    {
+                        "name": null,
                         "emoji": "SteamworksBoss",
                         "row": "steamworkRuns"
+                    },
+                    {
+                        "name": null,
+                        "emoji": "exaltedAdvancedSteamworks",
+                        "row": "advancedSteamworkRuns"
                     },
                     {
                         "name": null,


### PR DESCRIPTION
# ViBot [8.11.0] (MANUAL CHANGES NEEDED)
## Changelog
### Changes
- Added `Advanced Nest` and `Advanced Kogbold Steamworks` completes to the database
- Updated `;leaderboard` and `;stats` to show these completes
## Summary
### Manual Changes
- [x] Add columns to the database
```
ALTER TABLE halls.users
ADD COLUMN advancedSteamworkRuns INT DEFAULT 0,
ADD COLUMN advancedNestRuns INT DEFAULT 0;
```
Edit the following templates:
Set `Log Name` to `advancedNestRuns`
- [ ] Advanced Nest
- [x] VC-Less Advanced Nest
- [x] Exalted Advanced Nest
- [x] VC-Less Exalted Advanced Nest
Set `Log Name` to `advancedSteamworkRuns`
- [x] Advanced Kogbold Steamworks
- [x] VC-Less Advanced Kogbold Steamworks
- [x] VC-Less Exalted Advanced Kogbold Steamworks