### PR TITLE
[ON HOLD] smart delete

### DIFF
--- a/commands/vote.js
+++ b/commands/vote.js
@@ -58,7 +58,7 @@ class Vote {
         if (this.voteConfiguration.members.length == 0) { return await this.channel.send('No members found.'); }
 
         this.getVoteConfigurationButtons();
-        await this.message.delete();
+        await this.message.smartDelete();
         await this.sendConfirmationMessage();
         await this.updateConfirmationMessage();
     }
@@ -148,7 +148,7 @@ class Vote {
     }
 
     async endVoteConfigurationPhase(interaction) {
-        await interaction.message.delete();
+        await interaction.message.smartDelete();
         this.voteConfigurationMessageInteractionCollector.stop();
     }
 
@@ -203,8 +203,8 @@ class Vote {
         embedFeedbackConfigure.setDescription('Choose how many feedbacks you want ViBot to look through');
         const confirmationMessage = await interaction.reply({ embeds: [embedFeedbackConfigure], fetchReply: true });
         const choice = await confirmationMessage.confirmNumber(10, interaction.member.id);
-        if (!choice || isNaN(choice) || choice == 'Cancelled') return await confirmationMessage.delete();
-        await confirmationMessage.delete();
+        if (!choice || isNaN(choice) || choice == 'Cancelled') return await confirmationMessage.smartDelete();
+        await confirmationMessage.smartDelete();
         this.voteConfiguration.maximumFeedbacks = choice;
         await this.updateConfirmationMessage();
     }

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -87,6 +87,18 @@ Discord.BaseChannel.prototype.next = function Next(filter, requirementMessage, a
     });
 };
 
+Discord.Message.prototype.smartDelete = async function() {
+    if (this.deletable) {
+        return await this.delete()
+    }
+}
+
+Discord.BaseInteraction.prototype.smartDelete = async function() {
+    if (this.deletable) {
+        return await this.delete()
+    }
+}
+
 Discord.Message.prototype.replySuccess = async function() {
     return await this.react('✅')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibot",
-  "version": "8.10.5",
+  "version": "8.10.6",
   "description": "ViBot",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
# ViBot 8.10.6
## Changelog
### Features
- Instead of throwing an error whenever Vibot tries to delete something it can't, it will now run the extension called "smartDelete()" which will only try to delete the message if it is able to.