### PR TITLE
Minor `;mm` field reordering

### DIFF
--- a/commands/mutualmembers.js
+++ b/commands/mutualmembers.js
@@ -94,8 +94,8 @@ module.exports = {
         for (let i = 0; i < allRaidsDescriptionsChunks.length; i++) {
             raidsDescriptionFields = raidsDescriptionFields.concat(
                 { name: '\u200B', value: allRaidsTimesChunks[i].join('\n'), inline: true },
-                { name: '\u200B', value: '\u200B', inline: true },
-                { name: '\u200B', value: allRaidsDescriptionsChunks[i].join('\n'), inline: true }
+                { name: '\u200B', value: allRaidsDescriptionsChunks[i].join('\n'), inline: true },
+                { name: '\u200B', value: '\u200B', inline: true }
             );
         }
         raidsDescriptionFields[0].name = 'Raids';


### PR DESCRIPTION
# ViBot [X.X.X]
## Changelog
### Changes
- Changed the ordering of raidDescriptionFields so that the third column is the empty space instead of the second.
### Examples
OLD:
![image](https://github.com/ViBotTeam/ViBot/assets/114817251/b0a22785-1add-4d12-ac03-2a2ac084e515)
NEW:
![image](https://github.com/ViBotTeam/ViBot/assets/114817251/01883d3a-da84-49a5-b84c-a12a4580feb4)
